### PR TITLE
Memory reset to 5

### DIFF
--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -216,7 +216,8 @@ class ResourceSpec(
             if memory < 100e6 and memory < 0.05 * system_memory:
                 # Linux, BSD has cached memory, which should
                 # also be considered as unused memory
-                memory += cached_memory
+                # we consider half of cached memory can be recycled.
+                memory += cached_memory / 2
                 if memory >= 0.05 * system_memory:
                     memory = 0.05 * system_memory
                     logger.warning(

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -213,7 +213,7 @@ class ResourceSpec(
             memory = (avail_memory - object_store_memory - (redis_max_memory
                                                             if is_head else 0))
             if memory < 100e6 and memory < 0.05 * system_memory:
-                raise ValueError(
+                logger.warning(
                     "After taking into account object store and redis memory "
                     "usage, the amount of memory on this node available for "
                     "tasks and actors ({} GB) is less than {}% of total. "
@@ -222,6 +222,10 @@ class ResourceSpec(
                     "object_store_memory=<bytes>).".format(
                         round(memory / 1e9, 2),
                         int(100 * (memory / system_memory))))
+                memory = 0.05 * system_memory
+                logger.warning(
+                    "Reset memory for tasks and actors to {} GB.".format(
+                        round(memory / 1e9, 2)))
 
         spec = ResourceSpec(num_cpus, num_gpus, memory, object_store_memory,
                             resources, redis_max_memory)

--- a/python/ray/resource_spec.py
+++ b/python/ray/resource_spec.py
@@ -216,7 +216,8 @@ class ResourceSpec(
             if memory < 100e6 and memory < 0.05 * system_memory:
                 # Linux, BSD has cached memory, which should
                 # also be considered as unused memory
-                # we consider half of cached memory can be recycled.
+                # consider half of cached memory can be recycled.
+                # According to https://gitlab.com/procps-ng/procps/-/blob/master/proc/sysinfo.c#L805
                 memory += cached_memory / 2
                 if memory >= 0.05 * system_memory:
                     memory = 0.05 * system_memory
@@ -233,7 +234,6 @@ class ResourceSpec(
                         "object_store_memory=<bytes>).".format(
                             round(memory / 1e9, 2),
                             int(100 * (memory / system_memory))))
-
 
         spec = ResourceSpec(num_cpus, num_gpus, memory, object_store_memory,
                             resources, redis_max_memory)

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -409,6 +409,21 @@ def get_system_memory():
     return psutil_memory_in_bytes
 
 
+def get_cached_memory():
+    """Return the currently cached memory in bytes
+
+    Returns:
+        The total amount of cached memory
+    """
+    # Try to accurately figure out the cached memory.
+    psutil_virtual_memory = psutil.virtual_memory()
+    psutil_cached_memory_in_bytes = 0
+    if hasattr(psutil_virtual_memory, "cached"):
+        psutil_cached_memory_in_bytes = psutil_virtual_memory.cached
+
+    return psutil_cached_memory_in_bytes
+
+
 def _get_docker_cpus(
         cpu_quota_file_name="/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
         cpu_share_file_name="/sys/fs/cgroup/cpu/cpu.cfs_period_us",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

When I start a ray cluster in a machine that has low available mem but high buff/cache memory, a rayOutOfMemoryError is raised.

Cached memory in Linux, BSD should be considered.

```
 After taking into account object store and redis memory usage, the amount of memory on this node available for
 tasks and actors (0.0 GB) is less than 0% of total. You can adjust these settings with 
ray.init(memory=<bytes>, object_store_memory=<bytes>)
```

## Why are these changes needed?
1. Add util function to get cached memory.
2. Adjust available  memory to 5% of the system when cached memory meet the limit.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
