### PR TITLE
[security] support remote function whitelist

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -103,7 +103,6 @@ class FunctionActorManager:
         self._num_exported = 0
         # This is to protect self._num_exported when doing exporting
         self._export_lock = threading.Lock()
-        RemoteFunctionWhitelist.whitelist_init()
 
     def increase_task_counter(self, function_descriptor):
         function_id = function_descriptor.function_id

--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -31,6 +31,7 @@ from ray.util.inspect import (
     is_class_method,
     is_static_method,
 )
+from ray._private.security import RemoteFunctionWhitelist
 
 FunctionExecutionInfo = namedtuple(
     "FunctionExecutionInfo", ["function", "function_name", "max_calls"]
@@ -102,6 +103,7 @@ class FunctionActorManager:
         self._num_exported = 0
         # This is to protect self._num_exported when doing exporting
         self._export_lock = threading.Lock()
+        RemoteFunctionWhitelist.whitelist_init()
 
     def increase_task_counter(self, function_descriptor):
         function_id = function_descriptor.function_id
@@ -316,6 +318,9 @@ class FunctionActorManager:
         Returns:
             A FunctionExecutionInfo object.
         """
+        # Remote function whitelist check
+        RemoteFunctionWhitelist.whitelist_check(function_descriptor)
+
         function_id = function_descriptor.function_id
         # If the function has already been loaded,
         # There's no need to load again

--- a/python/ray/_private/security.py
+++ b/python/ray/_private/security.py
@@ -44,3 +44,5 @@ class RemoteFunctionWhitelist:
                 "Remote function module whitelist check failed "
                 f"for {function_descriptor}"
             )
+
+RemoteFunctionWhitelist.whitelist_init()

--- a/python/ray/_private/security.py
+++ b/python/ray/_private/security.py
@@ -1,0 +1,46 @@
+import os
+import logging
+import yaml
+import re
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR_NAME = "RAY_SECURERITY_CONFIG_PATH"
+
+RAY_SECURERITY_CONFIG_PATH = os.environ.get(ENV_VAR_NAME, None)
+
+
+class RemoteFunctionWhitelist:
+    module_whitelist = None
+
+    @classmethod
+    def whitelist_init(cls):
+        if RAY_SECURERITY_CONFIG_PATH:
+            cls.module_whitelist = yaml.safe_load(
+                open(RAY_SECURERITY_CONFIG_PATH, "rt")
+            ).get("remote_function_whitelist", None)
+            if cls.module_whitelist:
+                logger.info(
+                    "The remote function module whitelist have been set. It means that"
+                    " if your remote functions or actor classes are not included in "
+                    "the whitelist, your remote tasks or actors will fail. You can "
+                    "modify the environment variable %s to change the whitelist or "
+                    'disable this functionality by "unset %s" directly. The whitelist'
+                    " is %s.",
+                    ENV_VAR_NAME,
+                    ENV_VAR_NAME,
+                    cls.module_whitelist,
+                )
+
+    @classmethod
+    def whitelist_check(cls, function_descriptor):
+        if not cls.module_whitelist:
+            return
+        else:
+            for module in cls.module_whitelist:
+                if re.match(module, function_descriptor.module_name):
+                    return
+            raise KeyError(
+                "Remote function module whitelist check failed "
+                f"for {function_descriptor}"
+            )

--- a/python/ray/tests/test_security.py
+++ b/python/ray/tests/test_security.py
@@ -1,0 +1,53 @@
+import pytest
+import os
+import sys
+import yaml
+import ray
+from ray._private.security import ENV_VAR_NAME
+
+config_path = "/tmp/test.yaml"
+
+
+@pytest.fixture
+def enable_whitelist():
+    os.environ[ENV_VAR_NAME] = config_path
+    yield
+    del os.environ[ENV_VAR_NAME]
+
+
+@pytest.mark.parametrize("valid_whitelist", [True, False])
+def test_remote_function_whitelist(shutdown_only, enable_whitelist, valid_whitelist):
+    whitelist_config = {
+        "remote_function_whitelist": [
+            "test_security*" if valid_whitelist else "abc.def"
+        ]
+    }
+    yaml.safe_dump(whitelist_config, open(config_path, "wt"))
+    ray.init()
+
+    @ray.remote
+    class Foo:
+        def foo(self):
+            return "hello"
+
+    @ray.remote
+    def foo():
+        return "world"
+
+    # test for actor
+    f = Foo.remote()
+    if valid_whitelist:
+        assert ray.get(f.foo.remote()) == "hello"
+    else:
+        with pytest.raises(ray.exceptions.RayActorError):
+            ray.get(f.foo.remote())
+    # test for normal task
+    if valid_whitelist:
+        assert ray.get(foo.remote()) == "world"
+    else:
+        with pytest.raises(ray.exceptions.WorkerCrashedError):
+            ray.get(foo.remote())
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION

## Why are these changes needed?
Support a module level remote function whitelist. You can set the whitelist in a yaml file and set the env var `RAY_SECURERITY_CONFIG_PATH`. A yaml file example :
```
remote_function_whitelist:
- test_security*
```
We will check this whitelist by regular expression.

