### PR TITLE
Disable client-server by default.

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -339,7 +339,7 @@ def debug(address):
     "--ray-client-server-port",
     required=False,
     type=int,
-    default=10001,
+    default=None,
     help="the port number the ray client server will bind on. If not set, "
     "the ray client server will not be started.",
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Before this PR, `ray start --head` enables the ray-client-server by default.
After this PR, it's enabled by default:
![image](https://user-images.githubusercontent.com/19473861/169485955-88b10a1f-2ad3-4c52-944e-849c775a5f29.png)



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
